### PR TITLE
12/survey/survey wrapper

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -10,9 +10,9 @@ interface Props {
 const Card = (props: Props) => {
   const { card } = props;
   return (
-    <>
+    <Flex flexDirection="column" pb={3}>
       <Box width="15rem" height="10rem" borderRadius="1.25rem" background="#fff8d6" />
-      <Flex p={2} flexDirection="column" gap="5px">
+      <Flex p={2} flexDirection="column" gap="8px">
         <Flex>
           <Label
             height="1.2rem"
@@ -36,7 +36,7 @@ const Card = (props: Props) => {
           </Flex>
         </Flex>
 
-        <Label width="14.5rem" fontSize="1rem" fontWeight={800}>
+        <Label width="14.6rem" fontSize="1rem" fontWeight={800}>
           {card.title}
         </Label>
         <Flex>
@@ -55,7 +55,7 @@ const Card = (props: Props) => {
           ))}
         </Flex>
       </Flex>
-    </>
+    </Flex>
   );
 };
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -22,10 +22,11 @@ const Card = (props: Props) => {
             background="#ffa869"
             p={1}
             mt={1}
+            fontFamily="Pr-Bold"
           >
             {card.status}
           </Label>
-          <Label fontSize="0.7rem" color="#888888" m={2} mr={3}>
+          <Label fontSize="0.7rem" color="#888888" fontFamily="Pr-Regular" m={2} mr={3}>
             {useDate(new Date())} ~ {useDate(new Date())}
           </Label>
           <Flex flexDirection="column">
@@ -36,7 +37,7 @@ const Card = (props: Props) => {
           </Flex>
         </Flex>
 
-        <Label width="14.6rem" fontSize="1rem" fontWeight={800}>
+        <Label width="14.6rem" fontSize="1rem" fontFamily="Pr-Bold">
           {card.title}
         </Label>
         <Flex>
@@ -44,6 +45,7 @@ const Card = (props: Props) => {
             <Label
               key={category}
               fontSize="0.1rem"
+              fontFamily="Pr-Regular"
               color="white"
               borderRadius={10}
               background="#949494"

--- a/src/components/Card/dummyCards.ts
+++ b/src/components/Card/dummyCards.ts
@@ -2,7 +2,7 @@ const dummyCards = {
   title: '알파프로젝트 알파프로젝트 알파프로젝트에 대해 알아보자',
   status: '진행중',
   cnt: 435,
-  categorys: ['인구통계', '기프티콘추첨'],
+  categorys: ['인구통계'],
 };
 
 export default dummyCards;

--- a/src/components/Card/types.ts
+++ b/src/components/Card/types.ts
@@ -1,6 +1,6 @@
 type cardType = {
-  status: string;
   title: string;
+  status: string;
   cnt: number;
   categorys: string[];
 };

--- a/src/components/SurveyCardWrapper/SurveyCardWrapper.tsx
+++ b/src/components/SurveyCardWrapper/SurveyCardWrapper.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+import { Flex } from 'components/Box';
+import Pagination from '@mui/material/Pagination';
+
+interface WrapperProps {
+  children: ReactNode;
+}
+
+const SurveyCardWrapper = ({ children }: WrapperProps) => {
+  return (
+    <Flex flexDirection="column" alignItems="center">
+      <Flex flexWrap="wrap" gap="1rem">
+        {children}
+      </Flex>
+      <Pagination count={5} />
+    </Flex>
+  );
+};
+export default SurveyCardWrapper;

--- a/src/pages/Test.tsx
+++ b/src/pages/Test.tsx
@@ -2,9 +2,6 @@ import { useModal } from 'hooks/useModal';
 import { useCallback } from 'react';
 import { useSnackbar } from 'notistack';
 import { Sidebar } from 'components/common';
-import SurveyCardWrapper from 'components/SurveyCardWrapper/SurveyCardWrapper';
-import Card from 'components/Card/Card';
-import dummyCards from 'components/Card/dummyCards';
 
 type IAlert = {
   message: string;
@@ -87,20 +84,6 @@ const Test = () => {
           '엔터테인먼트',
         ]}
       />
-      <SurveyCardWrapper>
-        <Card card={dummyCards} />
-        <Card card={dummyCards} />
-        <Card card={dummyCards} />
-        <Card card={dummyCards} />
-        <Card card={dummyCards} />
-        <Card card={dummyCards} />
-        <Card card={dummyCards} />
-        <Card card={dummyCards} />
-        <Card card={dummyCards} />
-        <Card card={dummyCards} />
-        <Card card={dummyCards} />
-        <Card card={dummyCards} />
-      </SurveyCardWrapper>
     </>
   );
 };

--- a/src/pages/Test.tsx
+++ b/src/pages/Test.tsx
@@ -2,6 +2,9 @@ import { useModal } from 'hooks/useModal';
 import { useCallback } from 'react';
 import { useSnackbar } from 'notistack';
 import { Sidebar } from 'components/common';
+import SurveyCardWrapper from 'components/SurveyCardWrapper/SurveyCardWrapper';
+import Card from 'components/Card/Card';
+import dummyCards from 'components/Card/dummyCards';
 
 type IAlert = {
   message: string;
@@ -69,7 +72,6 @@ const Test = () => {
         </button>
       </div>
       <br />
-
       <Sidebar
         title="카테고리 선택"
         categorys={[
@@ -85,7 +87,20 @@ const Test = () => {
           '엔터테인먼트',
         ]}
       />
-      <br />
+      <SurveyCardWrapper>
+        <Card card={dummyCards} />
+        <Card card={dummyCards} />
+        <Card card={dummyCards} />
+        <Card card={dummyCards} />
+        <Card card={dummyCards} />
+        <Card card={dummyCards} />
+        <Card card={dummyCards} />
+        <Card card={dummyCards} />
+        <Card card={dummyCards} />
+        <Card card={dummyCards} />
+        <Card card={dummyCards} />
+        <Card card={dummyCards} />
+      </SurveyCardWrapper>
     </>
   );
 };


### PR DESCRIPTION
## 작업 내용

![스크린샷(238)](https://user-images.githubusercontent.com/55877726/235287395-c652e83c-c611-4596-b433-9d596556dbb1.png)
![스크린샷(239)](https://user-images.githubusercontent.com/55877726/235287396-ae761c8f-6b98-4a8a-b217-eb6e9ca6113f.png)

- flex로 화면 크기 줄어들 때 카드 개수도 줄어들게 구현했습니다.
- pagination은 mui 사용했습니다. 

## 사용 방법
- map 함수 이용해서 `<SurveyCardWrapper/> `안에 `<Card/>`여러 개 넣으면 됩니다. 